### PR TITLE
fix: Removed apostrophe typo from text

### DIFF
--- a/components/Sections/Pricing/HeroBlock/index.jsx
+++ b/components/Sections/Pricing/HeroBlock/index.jsx
@@ -10,7 +10,7 @@ const HeroBlock = () => {
               <h3 className="h3 text-white">
                 Amplication is an open-source project built by developers for
                 developers. Our main objective is to provide a free lifetime
-                `&#34;community developer license`&#34; to every developer around the
+                &#34;community developer license&#34; to every developer around the
                 world.
               </h3>
             </div>

--- a/components/Sections/Pricing/PricesTable/index.jsx
+++ b/components/Sections/Pricing/PricesTable/index.jsx
@@ -73,7 +73,7 @@ const PricesTable = () => {
             <div className="col-12 col-md-8 offset-md-2">
               <h1 className="main-title">Public Beta users</h1>
               <h3 className="h3 text-white">
-                While we`&quot;re in Beta Amplication is free to use. In the future,
+                While we&apos;re in Beta Amplication is free to use. In the future,
                 we will offer a free community plan and additional paid business
                 plans.
               </h3>

--- a/components/Sections/Pricing/PricesTable/index.jsx
+++ b/components/Sections/Pricing/PricesTable/index.jsx
@@ -83,10 +83,11 @@ const PricesTable = () => {
                 platform contains stable, documented, secured, and supported
                 production-ready open-source components & packages. Your app is
                 stable, scalable, and production-ready you can deploy and rely
-                on. Read more about the generated app and its stack
+                on. Read more about the generated app and its stack 
                 <Link href={'https://docs.amplication.com/docs/getting-started/'}>
-                  <a> here</a>
+                  <a>here</a>
                 </Link>
+                .
               </h3>
             </div>
           </div>


### PR DESCRIPTION
There's a weird typo on your site:

![image](https://user-images.githubusercontent.com/24637852/183615886-5eb17931-0dec-46f4-a40b-3c6769e1c0ed.png)
https://amplication.com/pricing

The apostrophe in `we're` is formatted weirdly. I've fixed this to be consistent with the apostrophe used elsewhere on your site

With the fix, the site looks like this:

![image](https://user-images.githubusercontent.com/24637852/183616885-371cb77e-2fe9-4be7-9676-ef7b37ca28ba.png)

Much nicer