### PR TITLE
config prettier-plugin-tailwindcss

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,46 @@
+# See https://prettier.io/docs/en/ignore.html for more about ignoring files.
+
+# dependencies
+node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel
+
+# ide
+.idea
+.vscode
+
+# config
+.lighthouseci
+.github
+
+# min files
+*.min.*

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  ...require('gts/.prettierrc.json')
-}
+  ...require('gts/.prettierrc.json'),
+  plugins: [require('prettier-plugin-tailwindcss')],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,8 @@
         "gts": "^3.1.0",
         "markdown-it": "^13.0.1",
         "postcss": "^8.4.16",
+        "prettier": "^2.8.0",
+        "prettier-plugin-tailwindcss": "^0.2.0",
         "prop-types": "^15.8.1",
         "sharp": "^0.31.0",
         "tailwindcss": "^3.1.8",
@@ -17171,9 +17173,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -17195,6 +17197,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.0.tgz",
+      "integrity": "sha512-Ruqig/mdWCSpqdq9WK44nrmqM4BFWTzBPhPGwC5NK3coV9eZntEQPB84MGZbjAg0XQU02jVRHXNRPREBzxvM+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -34335,9 +34349,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -34348,6 +34362,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.0.tgz",
+      "integrity": "sha512-Ruqig/mdWCSpqdq9WK44nrmqM4BFWTzBPhPGwC5NK3coV9eZntEQPB84MGZbjAg0XQU02jVRHXNRPREBzxvM+A==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "stage": "next start -p 3001",
     "lint": "gts lint",
     "fix": "gts fix",
-    "lhci": "lhci autorun"
+    "lhci": "lhci autorun",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "engines": {
     "node": ">=16.0.0 <17"
@@ -60,6 +62,8 @@
     "gts": "^3.1.0",
     "markdown-it": "^13.0.1",
     "postcss": "^8.4.16",
+    "prettier": "^2.8.0",
+    "prettier-plugin-tailwindcss": "^0.2.0",
     "prop-types": "^15.8.1",
     "sharp": "^0.31.0",
     "tailwindcss": "^3.1.8",


### PR DESCRIPTION
Fixes: amplication/amplication#4495

## PR Details
- added `prettier` and `prettier-plugin-tailwindcss` as dev dependencies
- added `prettier-plugin-tailwindcss` as a plugin to `prettierrc.js` config
- added scripts `format:check` and `format`
- configured `.prettierignore`
  - copy from .gitignore
  - add ide, config, and min-files sections
- Reference: https://github.com/tailwindlabs/prettier-plugin-tailwindcss

## Things to consider before merging
- [ ] checkout to this branch
- [ ] `npm run format:check` and check if any unwanted files are being formatted
  - [ ] Add these files/directories to `.prettierignore`
- [ ] `npm run format` and check if there are any issues in the formatting
- [ ] First formatting should be planned and handled in a separate issue/PR to avoid possible merge conflicts with existing branches
  - [ ] Setup pre-commit hook to ensure future commits are automatically formatted
