### PR TITLE
chore(terraform): enforce tls 1.2 and higher via ssl_policy

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,6 +84,7 @@ module "lb-http" {
   name    = var.lb_name
 
   ssl                             = true
+  ssl_policy                      = "tls-1-2"
   managed_ssl_certificate_domains = [var.domain, "www.${var.domain}"]
   http_forward                    = false
   create_url_map                  = false


### PR DESCRIPTION
<!--
Thank you for contributing to Amplication :)

PLEASE, GO THROUGH THESE STEPS BEFORE SUBMITTING A PR!

Make sure that:

1. There is an open issue for this PR. If not, please open one before submitting your changes. Before proceeding, any change needs to be discussed (You can skip this if you're fixing a typo or adding an app to the Showcase).

2. You have done your changes in a separate branch. Branches MUST have descriptive names that start with either the `fix/[issue #]-` or `feature/[issue #]-` prefixes. Good examples are: `fix/404-signin-issue` or `feature/201-new-templates`.

3. You are giving a descriptive title to your PR.

4. You are providing enough information about your changes for others to review your pull request.

-->

Fixes: amplication/amplication-infrastructure-next#185

## PR Details

<!-- Explain the details for making this change. What existing problem does the pull request solve? -->

This PR introduce the terraform changes to enforce an ssl_policy on the loadbalancer to make sure that it only accept connections with TLS version 1.2 and higher. This was requested for SEO purposes.

## PR Checklist
- [ ] `npm run test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
