### PR TITLE
fix(client): website roadmap display sorted

### DIFF
--- a/components/Sections/MainPage/Roadmap/index.jsx
+++ b/components/Sections/MainPage/Roadmap/index.jsx
@@ -82,8 +82,8 @@ const Roadmap = ({customClass}) => {
                 <ul className="roadmap-list">
                   <li className="done">Custom Code</li>
                   <li className="done">Continuos sync with Git</li>
-                  <li className="text-white">GitLab and other Git services</li>
                   <li className="done">Auto merge and conflict management</li>
+                  <li className="text-white">GitLab and other Git services</li>
                   <li className="text-white">Multiple branches</li>
                 </ul>
               </div>
@@ -93,10 +93,10 @@ const Roadmap = ({customClass}) => {
                 <div className="roadmap-title font-dmmono">CI/CD</div>
                 <ul className="roadmap-list">
                   <li className="done">Docker</li>
-                  <li className="text-white">Terraform</li>
                   <li className="done">Helm charts</li>
-                  <li className="text-white">Connect to private cloud</li>
                   <li className="done">GitHub Actions</li>
+                  <li className="text-white">Terraform</li>
+                  <li className="text-white">Connect to private cloud</li>
                   <li className="text-white">GitOps</li>
                 </ul>
               </div>


### PR DESCRIPTION
Fixes: amplication/amplication#6382

## PR Details

Sort the items within each category in the roadmap so that completed items show up above the open(remaining) items


![roadmap](https://github.com/amplication/amplication-site/assets/16662383/06f9e2b9-bb52-40bd-bd33-1c4d52133e55)
